### PR TITLE
FIDO2/YubiKey SSH and GPG integration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[packages/git/.config/git/config]
+[src/.config/{git,ssh}/config]
 indent_style = tab
+indent_size = 4
 tab_width = 4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+This is a personal dotfiles management system that works across macOS and Linux platforms. The repository manages configuration files using symlinks and includes provisioning scripts for various tools and environments.
+
+## Architecture
+
+The dotfiles system is built around a central shell script (`bin/dotfiles`) that manages configuration through symlinks:
+
+- **Configuration Source**: `src/` directory contains all configuration files in their target directory structure
+- **Symlink Management**: The dotfiles tool creates symlinks from `$HOME` to files in `src/`
+- **Shell Integration**: Automatic shell profile integration via `dotfiles init` command
+- **XDG Base Directory Compliance**: Uses XDG environment variables for organization
+
+### Key Components
+
+- `bin/dotfiles` - Main configuration management tool
+- `src/` - Source configuration files (mirrors target directory structure)
+- `etc/` - Shell profile files (bashrc, zshrc, profile.d modules)
+- `formula` - Homebrew formulas
+- `scripts/` - Platform-specific provisioning scripts
+- `install.sh` - Bootstrap installation script
+
+## Common Commands
+
+### Dotfiles Management
+```bash
+# Show status of all configuration files
+./bin/dotfiles status
+
+# Link all configuration files
+./bin/dotfiles link
+
+# Unlink all configuration files
+./bin/dotfiles unlink
+
+# Update dotfiles from git and re-link
+./bin/dotfiles update
+
+# Initialize shell integration
+./bin/dotfiles init
+
+# Run provisioning scripts
+./bin/dotfiles script macos
+./bin/dotfiles script developer
+```
+
+### Installation
+```bash
+# Fresh install (clones repo and links configs)
+./install.sh
+
+# Install with specific branch
+./install.sh -b <branch-name>
+
+# Uninstall (removes symlinks, restores backups)
+./uninstall.sh
+```
+
+### Development
+No build, test, or lint commands - this is a shell script-based configuration management system.
+
+## Directory Structure
+
+- `bin/` - The main dotfiles management script
+- `etc/` - Shell profile configuration (bashrc, zshrc, profile.d modules)
+- `scripts/` - Platform and tool-specific installation scripts
+- `src/` - Configuration files in target directory structure (e.g., `src/.config/vim/vimrc` → `~/.config/vim/vimrc`)
+
+## Script System
+
+The `scripts/` directory contains idempotent provisioning scripts for:
+- Platform setup (macos.sh, fedora.sh, ubuntu.sh)
+- Development tools (developer.sh, github.sh, zed.sh)
+- Applications (1password.sh, homebrew.sh, tailscale.sh)
+
+All scripts can be run independently and repeatedly without issues.
+
+## Key Environment Variables
+
+- `DOTFILES` - Location of dotfiles repository (default: `$XDG_DATA_HOME/dotfiles`)
+- `DOTFILES_CONFIG` - User config override directory (default: `$XDG_CONFIG_HOME/dotfiles`)
+- `TARGET` - Target directory for symlinks (default: `$HOME`)
+
+## Configuration Override
+
+User-specific configurations can be placed in `$XDG_CONFIG_HOME/dotfiles/` to override defaults without modifying the main repository.

--- a/bin/dotfiles
+++ b/bin/dotfiles
@@ -6,10 +6,11 @@ XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 XDG_DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
 LOCAL_BIN_HOME=${LOCAL_BIN_HOME:-$HOME/.local/bin}
 DOTFILES=${DOTFILES:-${XDG_DATA_HOME}/dotfiles}
+DOTFILES_BIN=${DOTFILES}/bin
 DOTFILES_SCRIPTS=${DOTFILES}/scripts
 DOTFILES_CONFIG=${XDG_CONFIG_HOME}/dotfiles
 
-dotfiles_command=$LOCAL_BIN_HOME/dotfiles
+dotfiles_command=${DOTFILES_BIN}/dotfiles
 
 TARGET=${TARGET:-$HOME}
 VERBOSE=0
@@ -94,7 +95,7 @@ shellenv() {
   printf 'export LOCAL_BIN_HOME=${LOCAL_BIN_HOME:-$HOME/.local/bin}\n'
   printf 'export DOTFILES=${DOTFILES:-$XDG_DATA_HOME/dotfiles}\n'
   printf 'export DOTFILES_CONFIG=${DOTFILES_CONFIG:-$XDG_CONFIG_HOME/dotfiles}\n'
-  printf 'export PATH=$LOCAL_BIN_HOME:$PATH\n'
+  printf 'export PATH=${LOCAL_BIN_HOME}:${DOTFILES}/bin:$PATH\n'
   printf '[ -f ${DOTFILES}/etc/profile ] && . ${DOTFILES}/etc/profile'
 }
 

--- a/bin/dotfiles
+++ b/bin/dotfiles
@@ -50,7 +50,7 @@ usage() {
   log "  unlink" "Unlink configuration"
   log "  update" "Update dotfiles"
   log "  edit" "Edit dotfiles in $EDITOR"
-  log "  script" "Run dofiles provisioning script"
+  log "  script" "Run dotfiles provisioning script [script1 script2 -- args]"
   log ""
   log "Options:" ""
   log "  -d" "dotfiles directory"
@@ -195,12 +195,37 @@ run_script() {
     return 0
   fi
 
-  # Run each provided script
-  for script in "$@"; do
+  # Parse arguments to find -- separator
+  script_names=""
+  script_args=""
+  found_separator=0
+
+  for arg in "$@"; do
+    if [ "$arg" = "--" ]; then
+      found_separator=1
+      continue
+    fi
+
+    if [ $found_separator -eq 0 ]; then
+      script_names="$script_names $arg"
+    else
+      script_args="$script_args $arg"
+    fi
+  done
+
+  # If no separator found, treat all args as script names (backward compatibility)
+  if [ $found_separator -eq 0 ]; then
+    script_names="$@"
+    script_args=""
+  fi
+
+  # Run each script with the provided arguments
+  for script in $script_names; do
     script_path="${DOTFILES_SCRIPTS}/${script}.sh"
     if [ -f "${script_path}" ]; then
       log "Running" "${script}"
-      sh "${script_path}"
+      # Execute script with proper terminal I/O for interaction
+      sh "${script_path}" $script_args </dev/tty
     else
       err "Script not found: ${script}.sh"
     fi

--- a/bin/gitconfig
+++ b/bin/gitconfig
@@ -2,8 +2,6 @@
 
 # Generate git config global file
 
-. ${DOTFILES}/etc/profile.d/1password.sh
-
 log() {
   if [ "$#" -eq 1 ]; then
     printf "%s\n" "$1"
@@ -125,15 +123,14 @@ gc_credentials() {
   gc_clear credential.helper
 
   git_cred_helper=""
-  if command -v op >/dev/null 2>&1; then
-    log "credentials" "1Password"
-    git_cred_helper="!op plugin run -- gh auth git-credential"
-  elif command -v gh >/dev/null 2>&1; then
+  if command -v gh >/dev/null 2>&1; then
     log "credentials" "gh"
-    git_cred_helper="!gh auth git-credential"
+    gh auth setup-git
+    # git_cred_helper="!$(command -v gh) auth git-credential"
   elif command -v git-credential-manager >/dev/null 2>&1; then
     log "credentials" "gcm"
-    git_cred_helper="$(command -v git-credential-manager)"
+    git-credential-manager configure
+    # git_cred_helper="$(command -v git-credential-manager)"
   else
     case $(uname) in
     Darwin)
@@ -145,15 +142,8 @@ gc_credentials() {
       git_cred_helper="cache"
       ;;
     esac
+    gc_add credential.helper "$git_cred_helper"
   fi
-
-  # Configure GitHub
-  gh_urls="https://github.com https://gist.github.com"
-  for url in $gh_urls; do
-    gc_clear credential.${url}.helper
-    gc_add credential.${url}.helper ''
-    gc_add credential.${url}.helper "$git_cred_helper"
-  done
 
   # Configure Azure DevOps if GCM is installed
   if command -v git-credential-manager >/dev/null 2>&1; then
@@ -172,7 +162,7 @@ gc_credentials() {
 }
 
 gc_commitsigning() {
-  # Clear gpg/ssh signing
+  # Clear signing keys
   gc_clear user.signingkey
   gc_clear gpg.format
   gc_clear gpg.ssh.program
@@ -180,54 +170,52 @@ gc_commitsigning() {
   gc_clear gpg.ssh.allowedSignersFile
 
   if [ $unset -eq 1 ]; then
-    vlog "skip" "GPG/SSH Signing keys"
+    vlog "skip" "Commit signing keys"
     return
   fi
 
-  # Configure gpg signing
-  if command -v op >/dev/null 2>&1; then
-    # Use 1Password SSH for signing
-    signing_key=$(op read "op://Private/GitHub SSH/public key")
-    if [ -n "$signing_key" ]; then
-      # Use ssh for signing. Requires SSH_AUTH_SOCK to be set
-      log "signingkey" "$signing_key"
-      gc_set user.signingkey "$signing_key"
-      gc_set gpg.format ssh
-      gc_set commit.gpgsign true
+  # Configure commit signing using SSH
+  # Get public key from attached YubiKey resident SSH key
+  signing_key=""
+  if command -v ssh-add >/dev/null 2>&1; then
+    # Try to get YubiKey public key from ssh-agent
+    signing_key=$(ssh-add -L 2>/dev/null | grep -E "(sk-|ecdsa-sk|ed25519-sk)" | head -n1)
+  fi
 
-      gpg_ssh_cmd=""
-      if command -v op-ssh-sign >/dev/null 2>&1; then
-        gpg_ssh_cmd="op-ssh-sign"
-      elif [ -x /Applications/1Password.app/Contents/MacOS/op-ssh-sign ]; then
-        gpg_ssh_cmd="/Applications/1Password.app/Contents/MacOS/op-ssh-sign"
-      elif [ -x /run/host/opt/1Password/op-ssh-sign ]; then
-        gpg_ssh_cmd=/run/host/opt/1Password/op-ssh-sign
-      fi
-      if [ -n "$gpg_ssh_cmd" ]; then
-        gc_set gpg.ssh.program $gpg_ssh_cmd
-      fi
-    fi
+  # Fallback: check for downloaded resident keys
+  if [ -z "$signing_key" ] && [ -f ~/.ssh/id_ed25519_sk.pub ]; then
+    signing_key=$(cat ~/.ssh/id_ed25519_sk.pub)
+  fi
+
+  if [ -n "$signing_key" ]; then
+    # Use ssh for signing. Requires SSH_AUTH_SOCK to be set
+    log "signingkey" "$(echo "$signing_key" | cut -d' ' -f1-2)"
+    gc_set user.signingkey "$signing_key"
+    gc_set gpg.format ssh
+    # gc_set commit.gpgsign true
   fi
 
   if [ -n "${ghuser}" ]; then
-    # Download signing keys from GitHub
-    signers="$HOME/.ssh/allowed_signers"
-    signing_keys=$(gh api users/${ghuser}/ssh_signing_keys --jq '.[] | .key | @text')
+    if command -v gh >/dev/null 2>&1; then
+      # Download signing keys from GitHub
+      signers="$HOME/.ssh/allowed_signers"
+      signing_keys=$(gh api users/${ghuser}/ssh_signing_keys --jq '.[] | .key | @text')
 
-    # Use POSIX-compliant loop
-    echo "$signing_keys" | while read -r pubkey; do
-      if ! grep -q -F "$pubkey" "$signers" 2>/dev/null; then
-        # Add the key, narrowly scoped for Git
-        log "add" "Signing key ${pubkey} for ${ghuser}"
-        mkdir -p "$(dirname "${signers}")"
-        echo "${ghuser} namespaces=\"git\" ${pubkey}" >>${signers}
-      else
-        vlog "exists" "Signing key ${pubkey} for ${ghuser}"
+      # Use POSIX-compliant loop
+      echo "$signing_keys" | while read -r pubkey; do
+        if ! grep -q -F "$pubkey" "$signers" 2>/dev/null; then
+          # Add the key, narrowly scoped for Git
+          log "add" "Signing key ${pubkey} for ${ghuser}"
+          mkdir -p "$(dirname "${signers}")"
+          echo "${ghuser} namespaces=\"git\" ${pubkey}" >>${signers}
+        else
+          vlog "exists" "Signing key ${pubkey} for ${ghuser}"
+        fi
+      done
+
+      if [ -s ${signers} ]; then
+        gc_set gpg.ssh.allowedSignersFile "$signers"
       fi
-    done
-
-    if [ -s ${signers} ]; then
-      gc_set gpg.ssh.allowedSignersFile "$signers"
     fi
   fi
 }
@@ -272,10 +260,8 @@ fi
 touch "${GIT_CONFIG_FILE}"
 
 vlog "config file" "${GIT_CONFIG_FILE}"
-gc_tools
 gc_user
 gc_credentials
 gc_commitsigning
+gc_tools
 gc_lfs
-
-# vim: set ft=sh ts=2 sw=2 et:

--- a/bin/gitconfig
+++ b/bin/gitconfig
@@ -125,6 +125,7 @@ gc_credentials() {
   git_cred_helper=""
   if command -v gh >/dev/null 2>&1; then
     log "credentials" "gh"
+
     gh auth setup-git
     # git_cred_helper="!$(command -v gh) auth git-credential"
   elif command -v git-credential-manager >/dev/null 2>&1; then
@@ -175,29 +176,22 @@ gc_commitsigning() {
   fi
 
   # Configure commit signing using SSH
-  # Get public key from attached YubiKey resident SSH key
-  signing_key=""
-  if command -v ssh-add >/dev/null 2>&1; then
-    # Try to get YubiKey public key from ssh-agent
-    signing_key=$(ssh-add -L 2>/dev/null | grep -E "(sk-|ecdsa-sk|ed25519-sk)" | head -n1)
-  fi
-
-  # Fallback: check for downloaded resident keys
-  if [ -z "$signing_key" ] && [ -f ~/.ssh/id_ed25519_sk.pub ]; then
-    signing_key=$(cat ~/.ssh/id_ed25519_sk.pub)
-  fi
-
-  if [ -n "$signing_key" ]; then
-    # Use ssh for signing. Requires SSH_AUTH_SOCK to be set
-    log "signingkey" "$(echo "$signing_key" | cut -d' ' -f1-2)"
-    gc_set user.signingkey "$signing_key"
+  # Get YubiKey keys and save with unique naming
+  yubikey_private_path=$(get_yubikey_keys)
+  if [ -n "$yubikey_private_path" ]; then
+    # Use ssh for signing. This will prompt for YubiKey PIN when signing
+    log "signingkey" "YubiKey SSH key: $(basename "$yubikey_private_path")"
+    gc_set user.signingkey "$yubikey_private_path"
     gc_set gpg.format ssh
     gc_set commit.gpgsign true
+  else
+    vlog "warning" "No YubiKey resident SSH key found"
   fi
 
   if [ -n "${ghuser}" ]; then
     if command -v gh >/dev/null 2>&1; then
       # Download signing keys from GitHub
+
       signers="$HOME/.ssh/allowed_signers"
       signing_keys=$(gh api users/${ghuser}/ssh_signing_keys --jq '.[] | .key | @text')
 
@@ -218,6 +212,56 @@ gc_commitsigning() {
       fi
     fi
   fi
+}
+
+# Get YubiKey SSH keys from resident keys and save with unique naming
+# Returns the path to the private key file on success
+get_yubikey_keys() {
+  if ! command -v ssh-keygen >/dev/null 2>&1 || ! command -v ykman >/dev/null 2>&1; then
+    return 1
+  fi
+
+  # Get YubiKey serial number for unique identification
+  yubikey_serial=$(ykman info 2>/dev/null | grep "Serial number:" | awk '{print $3}')
+  if [ -z "$yubikey_serial" ]; then
+    vlog "error" "Could not get YubiKey serial number"
+    return 1
+  fi
+
+  # Create temporary directory for key download
+  temp_dir=$(mktemp -d)
+  trap 'rm -rf "$temp_dir"' EXIT
+
+  # Change to temp directory and download resident keys from YubiKey (will prompt for PIN)
+  if (cd "$temp_dir" && ssh-keygen -K -f "id_" -N "" >/dev/null 2>&1); then
+    # Find the first hardware key files
+    private_key_file=$(find "$temp_dir" -name "*_sk_rk_*" -not -name "*.pub" | head -n1)
+    public_key_file=$(find "$temp_dir" -name "*_sk_rk_*.pub" | head -n1)
+
+    if [ -n "$private_key_file" ] && [ -n "$public_key_file" ]; then
+      # Extract algorithm from public key (e.g., "ed25519" from "sk-ssh-ed25519@openssh.com")
+      algorithm=$(head -1 "$public_key_file" | cut -d' ' -f1 | sed 's/sk-ssh-//' | sed 's/@.*//')
+
+      # Construct filename: id_<serial>_<algorithm>_sk
+      key_filename="id_${yubikey_serial}_${algorithm}_sk"
+      yubikey_private_path="$HOME/.ssh/$key_filename"
+      yubikey_public_path="$HOME/.ssh/${key_filename}.pub"
+
+      # Save keys with unique naming
+      mkdir -p "$(dirname "$yubikey_private_path")"
+      cp "$private_key_file" "$yubikey_private_path"
+      cp "$public_key_file" "$yubikey_public_path"
+
+      # Set proper permissions
+      chmod 600 "$yubikey_private_path"
+      chmod 644 "$yubikey_public_path"
+
+      echo "$yubikey_private_path"
+      return 0
+    fi
+  fi
+
+  return 1
 }
 
 gc_lfs() {

--- a/bin/gitconfig
+++ b/bin/gitconfig
@@ -175,90 +175,33 @@ gc_commitsigning() {
     return
   fi
 
-  # Configure commit signing using SSH
-  # Get YubiKey keys and save with unique naming
-  yubikey_private_path=$(get_yubikey_keys)
-  if [ -n "$yubikey_private_path" ]; then
-    # Use ssh for signing. This will prompt for YubiKey PIN when signing
-    log "signingkey" "YubiKey SSH key: $(basename "$yubikey_private_path")"
-    gc_set user.signingkey "$yubikey_private_path"
-    gc_set gpg.format ssh
+  # Configure commit signing using GPG
+  # Get GPG signing key from YubiKey
+  signing_key_id=$(get_gpg_signing_key)
+  if [ -n "$signing_key_id" ]; then
+    # Use GPG for signing. This will prompt for YubiKey PIN when signing
+    log "signingkey" "YubiKey GPG key: $signing_key_id"
+    gc_set user.signingkey "$signing_key_id"
     gc_set commit.gpgsign true
+    gc_set tag.gpgsign true
   else
-    vlog "warning" "No YubiKey resident SSH key found"
-  fi
-
-  if [ -n "${ghuser}" ]; then
-    if command -v gh >/dev/null 2>&1; then
-      # Download signing keys from GitHub
-
-      signers="$HOME/.ssh/allowed_signers"
-      signing_keys=$(gh api users/${ghuser}/ssh_signing_keys --jq '.[] | .key | @text')
-
-      # Use POSIX-compliant loop
-      echo "$signing_keys" | while read -r pubkey; do
-        if ! grep -q -F "$pubkey" "$signers" 2>/dev/null; then
-          # Add the key, narrowly scoped for Git
-          log "add" "Signing key ${pubkey} for ${ghuser}"
-          mkdir -p "$(dirname "${signers}")"
-          echo "${ghuser} namespaces=\"git\" ${pubkey}" >>${signers}
-        else
-          vlog "exists" "Signing key ${pubkey} for ${ghuser}"
-        fi
-      done
-
-      if [ -s ${signers} ]; then
-        gc_set gpg.ssh.allowedSignersFile "$signers"
-      fi
-    fi
+    vlog "warning" "No YubiKey GPG signing key found"
   fi
 }
 
-# Get YubiKey SSH keys from resident keys and save with unique naming
-# Returns the path to the private key file on success
-get_yubikey_keys() {
-  if ! command -v ssh-keygen >/dev/null 2>&1 || ! command -v ykman >/dev/null 2>&1; then
+# Get GPG signing key ID
+get_gpg_signing_key() {
+  if ! command -v gpg >/dev/null 2>&1; then
     return 1
   fi
 
-  # Get YubiKey serial number for unique identification
-  yubikey_serial=$(ykman info 2>/dev/null | grep "Serial number:" | awk '{print $3}')
-  if [ -z "$yubikey_serial" ]; then
-    vlog "error" "Could not get YubiKey serial number"
-    return 1
-  fi
+  # Get the signing key ID from secret key list
+  # Parse colon-separated output: find first secret subkey (ssb) with signing capability (s) and return key ID (field 5)
+  signing_key=$(gpg --list-secret-keys --with-colons 2>/dev/null | awk -F: '/^ssb/ && $12 ~ /s/ {print $5; exit}')
 
-  # Create temporary directory for key download
-  temp_dir=$(mktemp -d)
-  trap 'rm -rf "$temp_dir"' EXIT
-
-  # Change to temp directory and download resident keys from YubiKey (will prompt for PIN)
-  if (cd "$temp_dir" && ssh-keygen -K -f "id_" -N "" >/dev/null 2>&1); then
-    # Find the first hardware key files
-    private_key_file=$(find "$temp_dir" -name "*_sk_rk_*" -not -name "*.pub" | head -n1)
-    public_key_file=$(find "$temp_dir" -name "*_sk_rk_*.pub" | head -n1)
-
-    if [ -n "$private_key_file" ] && [ -n "$public_key_file" ]; then
-      # Extract algorithm from public key (e.g., "ed25519" from "sk-ssh-ed25519@openssh.com")
-      algorithm=$(head -1 "$public_key_file" | cut -d' ' -f1 | sed 's/sk-ssh-//' | sed 's/@.*//')
-
-      # Construct filename: id_<serial>_<algorithm>_sk
-      key_filename="id_${yubikey_serial}_${algorithm}_sk"
-      yubikey_private_path="$HOME/.ssh/$key_filename"
-      yubikey_public_path="$HOME/.ssh/${key_filename}.pub"
-
-      # Save keys with unique naming
-      mkdir -p "$(dirname "$yubikey_private_path")"
-      cp "$private_key_file" "$yubikey_private_path"
-      cp "$public_key_file" "$yubikey_public_path"
-
-      # Set proper permissions
-      chmod 600 "$yubikey_private_path"
-      chmod 644 "$yubikey_public_path"
-
-      echo "$yubikey_private_path"
-      return 0
-    fi
+  if [ -n "$signing_key" ]; then
+    echo "$signing_key"
+    return 0
   fi
 
   return 1

--- a/bin/gitconfig
+++ b/bin/gitconfig
@@ -192,7 +192,7 @@ gc_commitsigning() {
     log "signingkey" "$(echo "$signing_key" | cut -d' ' -f1-2)"
     gc_set user.signingkey "$signing_key"
     gc_set gpg.format ssh
-    # gc_set commit.gpgsign true
+    gc_set commit.gpgsign true
   fi
 
   if [ -n "${ghuser}" ]; then

--- a/bin/ssh-askpass
+++ b/bin/ssh-askpass
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+case "$1" in
+"Confirm user presence"*)
+  message="SETDESC $1\nCONFIRM\n"
+  CONFIRM=$(printf "$message" | pinentry-mac | tail -n 1 | tr -d '\n')
+  # Check if user cancelled (not OK means cancel)
+  if [ "$CONFIRM" != "OK" ]; then
+    exit 1
+  fi
+  ;;
+*)
+  # See if we can get the hash of the key
+  # that we want the password for
+  # (this enables keychain option support)
+  HASHTYPE=$(echo $1 | awk -F':' '{print $1}')
+  case "$HASHTYPE" in
+  *"SHA256")
+    # Grab the actual hash
+    SHA256=$(echo $1 | awk -F':' '{print $2}')
+    message="SETDESC $1\nOPTION allow-external-password-cache\nSETKEYINFO $SHA256\nGETPIN\n"
+    ;;
+  *)
+    # Otherwise don't include the keyinfo
+    message="SETDESC $1\nGETPIN\n"
+    ;;
+  esac
+
+  # Prompt the user for their pin
+  PIN=$(printf "$message" | pinentry-mac | grep D | tr -d '\n')
+  # Return the pin to ssh-agent starting after 'D '
+  echo "${PIN:2}"
+  ;;
+esac

--- a/etc/profile
+++ b/etc/profile
@@ -26,6 +26,11 @@ if command -v ssh-askpass >/dev/null; then
   export DISPLAY=:0
 fi
 
+if [ -n "${SSH_CONNECTION}" ]; then
+  export PINENTRY_USER_DATA=USE_CURSES=1
+  export GPG_TTY=$(tty)
+fi
+
 # Detect shell and run matching rc script
 if [ -n "$BASH_VERSION" ]; then
   [ -f ${DOTFILES}/etc/bashrc ] && . ${DOTFILES}/etc/bashrc

--- a/etc/profile
+++ b/etc/profile
@@ -7,6 +7,7 @@ export INPUTRC="${XDG_CONFIG_HOME}/readline/inputrc"
 # * Verify brew is installed
 # * Intialize brew for shell environment if interactive
 export HOMEBREW_NO_EMOJI=1
+export HOMEBREW_DOWNLOAD_CONCURRENCY=auto
 if [[ $- == *i* ]]; then
   if [ -d /opt/homebrew ]; then
     eval "$(/opt/homebrew/bin/brew shellenv)"
@@ -18,6 +19,11 @@ fi
 # Set SSH key provider for FIDO2
 if [ -f /usr/local/lib/sk-libfido2.dylib ]; then
   export SSH_SK_PROVIDER=/usr/local/lib/sk-libfido2.dylib
+fi
+
+if command -v ssh-askpass >/dev/null; then
+  export SSH_ASKPASS=ssh-askpass
+  export DISPLAY=:0
 fi
 
 # Detect shell and run matching rc script

--- a/etc/profile
+++ b/etc/profile
@@ -15,6 +15,11 @@ if [[ $- == *i* ]]; then
   fi
 fi
 
+# Set SSH key provider for FIDO2
+if [ -f ${HOMEBREW_PREFIX}/lib/sk-libfido2.dylib ]; then
+  export SSH_SK_PROVIDER=${HOMEBREW_PREFIX}/lib/sk-libfido2.dylib
+fi
+
 # Detect shell and run matching rc script
 if [ -n "$BASH_VERSION" ]; then
   [ -f ${DOTFILES}/etc/bashrc ] && . ${DOTFILES}/etc/bashrc
@@ -23,11 +28,9 @@ elif [ -n "$ZSH_VERSION" ]; then
 fi
 
 if [ -d ${DOTFILES}/etc/profile.d ]; then
-  for rc in ${DOTFILES}/etc/profile.d/* ; do
+  for rc in ${DOTFILES}/etc/profile.d/*; do
     if [ -f "$rc" ]; then
       . "$rc"
     fi
   done
 fi
-
-# vim: set ft=sh ts=2 sw=2 et:

--- a/etc/profile
+++ b/etc/profile
@@ -16,8 +16,8 @@ if [[ $- == *i* ]]; then
 fi
 
 # Set SSH key provider for FIDO2
-if [ -f ${HOMEBREW_PREFIX}/lib/sk-libfido2.dylib ]; then
-  export SSH_SK_PROVIDER=${HOMEBREW_PREFIX}/lib/sk-libfido2.dylib
+if [ -f /usr/local/lib/sk-libfido2.dylib ]; then
+  export SSH_SK_PROVIDER=/usr/local/lib/sk-libfido2.dylib
 fi
 
 # Detect shell and run matching rc script

--- a/etc/profile.d/1password.sh
+++ b/etc/profile.d/1password.sh
@@ -1,20 +1,5 @@
 # 1Password shell configuration
 
-if [ -z "$SSH_TTY" ] && [ -S "${HOME}/.1password/agent.sock" ]; then
-  export SSH_AUTH_SOCK="${HOME}/.1password/agent.sock"
-fi
-
-# 1Password cli in toolbox
-if [ -f /run/.containerenv ] && [ -d /run/host/opt/1Password ]; then
-  alias op=/run/host/bin/op
-  alias op-ssh-sign=/run/host/opt/1Password/op-ssh-sign
-fi
-
-# 1Password plugins
-if [ -f "${XDG_CONFIG_HOME}/op/plugins.sh" ]; then
-  source "${XDG_CONFIG_HOME}/op/plugins.sh"
-fi
-
 # 1Password completions
 # Only load completions in interactive Bash or Zsh, skip for /bin/sh
 if [ -n "$PS1" ] && command -v op >/dev/null 2>&1; then

--- a/etc/profile.d/github.sh
+++ b/etc/profile.d/github.sh
@@ -1,32 +1,20 @@
 # GitHub CLI configuration
 
-# Check if gh is installed and gh extension copilot is installed
-if command -v gh >/dev/null 2>&1; then
-  # GitHub aliases
-  # Only load aliases in interactive Bash or Zsh, skip for /bin/sh
-  if [ -n "$PS1" ] && command -v op >/dev/null 2>&1; then
-    # Check if we're directly in bash or zsh (not just any shell with PS1 set)
+# Only load aliases in interactive shell
+if [ -n "$PS1" ] && command -v gh >/dev/null 2>&1; then
+  # Generate GitHub Copilot aliases
+  if gh extension list | grep -q copilot; then
     case "$SHELL" in
     *bash)
       if [ -n "$BASH_VERSION" ]; then
-        if [ -f "${DOTFILES_CONFIG}/gh-copilot-bash.sh" ]; then
-          . "${DOTFILES_CONFIG}/gh-copilot-bash.sh"
-        else
-          eval "$(gh copilot alias -- bash)"
-        fi
+        eval "$(gh copilot alias -- bash)"
       fi
       ;;
     *zsh)
       if [ -n "$ZSH_VERSION" ]; then
-        if [ -f "${DOTFILES_CONFIG}/gh-copilot-zsh.sh" ]; then
-          . "${DOTFILES_CONFIG}/gh-copilot-zsh.sh"
-        else
-          eval "$(gh copilot alias -- zsh)"
-        fi
+        eval "$(gh copilot alias -- zsh)"
       fi
       ;;
     esac
   fi
 fi
-
-# vim: set ft=sh ts=2 sw=2 et:

--- a/formula/sk-libfido2.rb
+++ b/formula/sk-libfido2.rb
@@ -1,0 +1,95 @@
+class SkLibfido2 < Formula
+  desc "Standalone security key library for OpenSSH YubiKey SSH resident keys"
+  homepage "https://www.openssh.com/"
+  url "https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-10.0p2.tar.gz"
+  mirror "https://cloudflare.cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-10.10p2.tar.gz"
+  version "10.0p2"
+  sha256 "021a2e709a0edf4250b1256bd5a9e500411a90dddabea830ed59cef90eb9d85c"
+  license "SSH-OpenSSH"
+
+  livecheck do
+    url "https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/"
+    regex(/href=.*?openssh[._-]v?(\d+(?:\.\d+)+(?:p\d+)?)\.t/i)
+  end
+
+  depends_on "pkgconf" => :build
+  depends_on "libfido2"
+  depends_on "openssl@3"
+
+  uses_from_macos "zlib"
+
+  def install
+    # Configure OpenSSH with minimal dependencies needed for security key support
+    args = %W[
+      --prefix=#{prefix}
+      --with-security-key-standalone
+    ]
+
+    system "./configure", *args
+
+    # Build only the components we need for the standalone security key library
+    system "make", "sk-libfido2.#{shared_library_extension}"
+
+    # Install the standalone library
+    lib.install "sk-libfido2.#{shared_library_extension}"
+
+    # Create platform-appropriate symlinks for consistency
+    if OS.mac?
+      # On macOS, create .so symlink for applications expecting Linux naming
+      lib.install_symlink "sk-libfido2.dylib" => "sk-libfido2.so"
+    end
+  end
+
+  def caveats
+    <<~EOS
+      This formula installs only the standalone security key library for OpenSSH.
+
+      To use YubiKey SSH resident keys with OpenSSH, you need:
+      1. OpenSSH 8.2+ (install via 'brew install openssh' if needed)
+      2. This library installed at: #{lib}/sk-libfido2.#{shared_library_extension}
+      3. Set the SSH_SK_PROVIDER environment variable
+
+      Add this to your shell profile (~/.zshrc, ~/.bashrc, etc.):
+        export SSH_SK_PROVIDER=#{lib}/sk-libfido2.#{shared_library_extension}
+
+      Alternately, set provider in ~/.ssh/config:
+        SecurityKeyProvider #{lib}/sk-libfido2.#{shared_library_extension}
+
+      The library will be automatically discovered by OpenSSH's ssh-keygen and
+      ssh-add commands when generating or using FIDO2/U2F keys.
+
+      To generate a resident key:
+        ssh-keygen -t ecdsa-sk -O resident -f ~/.ssh/id_ecdsa_sk
+
+      To load resident keys from your YubiKey:
+        ssh-add -K
+    EOS
+  end
+
+  test do
+    # Test that the library exists and is a proper shared library
+    assert_predicate lib/"sk-libfido2.#{shared_library_extension}", :exist?
+
+    if OS.mac?
+      assert_match "Mach-O", shell_output("file #{lib}/sk-libfido2.dylib")
+      # Test symlink exists on macOS
+      assert_predicate lib/"sk-libfido2.so", :exist?
+    else
+      assert_match "ELF", shell_output("file #{lib}/sk-libfido2.so")
+    end
+
+    # Test that required symbols are exported (use nm or objdump depending on platform)
+    nm_cmd = OS.mac? ? "nm" : "nm -D"
+    output = shell_output("#{nm_cmd} #{lib}/sk-libfido2.#{shared_library_extension} 2>/dev/null || nm #{lib}/sk-libfido2.#{shared_library_extension}")
+
+    %w[sk_api_version sk_enroll sk_sign sk_load_resident_keys].each do |symbol|
+      assert_match symbol, output, "Required symbol #{symbol} not found in library"
+    end
+  end
+
+  private
+
+  def shared_library_extension
+    OS.mac? ? "dylib" : "so"
+  end
+end

--- a/formula/sk-libfido2.rb
+++ b/formula/sk-libfido2.rb
@@ -32,12 +32,6 @@ class SkLibfido2 < Formula
 
     # Install the standalone library
     lib.install "sk-libfido2.#{shared_library_extension}"
-
-    # Create platform-appropriate symlinks for consistency
-    if OS.mac?
-      # On macOS, create .so symlink for applications expecting Linux naming
-      lib.install_symlink "sk-libfido2.dylib" => "sk-libfido2.so"
-    end
   end
 
   def caveats

--- a/install.sh
+++ b/install.sh
@@ -118,20 +118,6 @@ else
   fi
 fi
 
-# Install dotfiles symlinks
-mkdir -p "$LOCAL_BIN_HOME"
-for dfbin in ${DOTFILES}/bin/*; do
-  bin="$LOCAL_BIN_HOME/${dfbin##*/}"
-  if ! [ -L $bin ]; then
-    if [ -e $bin ]; then
-      echo "Conflict: $bin exists" >&2
-    else
-      echo "link $dfbin -> $bin"
-      ln -s $dfbin $bin
-    fi
-  fi
-done
-
 # Init dotfiles
 "${DOTFILES}/bin/dotfiles" ${FLAGS} -d "${DOTFILES}" -t "${TARGET}" init
 

--- a/scripts/1password.sh
+++ b/scripts/1password.sh
@@ -4,21 +4,12 @@
 
 set -eu
 
-op_container_sock=${HOME}/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock
-op_agent_sock=${HOME}/.1password/agent.sock
-
 case $(uname -s) in
 Darwin)
   # Use homebrew to install 1Password
   if command -v brew >/dev/null 2>&1; then
     brew install --adopt --cask 1password
     brew install --cask 1password-cli
-
-    # Symlink 1P agent socket to standard location ~/.1password/agent.sock
-    if [ -S "${op_container_sock}" ] && ! [ -L "${op_agent_sock}" ]; then
-      mkdir -p ${HOME}/.1password
-      ln -s "${op_container_sock}" "${op_agent_sock}"
-    fi
   else
     echo "Homebrew is not installed. Please install Homebrew first."
     exit 1
@@ -69,28 +60,3 @@ Linux)
   esac
   ;;
 esac
-
-# Configure 1P SSH
-XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
-dotfiles_ssh_config=${XDG_CONFIG_HOME}/ssh/config
-
-if [ -S "${op_container_sock}" ]; then
-  if ! [ -f ${HOME}/.ssh/config ] || ! grep -q -x "Include ${dotfiles_ssh_config}" ${HOME}/.ssh/config; then
-    echo "Enable SSH IdentityAgent"
-    mkdir -p ${HOME}/.ssh
-    echo "Include ${dotfiles_ssh_config}" >>${HOME}/.ssh/config
-  fi
-fi
-
-# 1Password CLI
-if command -v op >/dev/null 2>&1; then
-  if command -v gh >/dev/null 2>&1; then
-    op plugin init gh
-    if [ -f "${XDG_CONFIG_HOME}/op/plugins.sh" ]; then
-      source "${XDG_CONFIG_HOME}/op/plugins.sh"
-    fi
-    op plugin inspect gh
-  fi
-fi
-
-# vim: set ft=sh ts=2 sw=2 et:

--- a/scripts/github.sh
+++ b/scripts/github.sh
@@ -2,27 +2,10 @@
 
 set -eu
 
-# Enable 1Password plugins
-if [ -f "${XDG_CONFIG_HOME}/op/plugins.sh" ]; then
-  source "${XDG_CONFIG_HOME}/op/plugins.sh"
-fi
-
 # GitHub CLI extensions installer
 if command -v gh >/dev/null 2>&1; then
-  echo "Install gh extensions"
   gh auth status || true
   for extension in github/gh-copilot; do
-    echo "GitHub CLI extension ${extension}"
     gh extension install ${extension} || true
   done
-
-  # Generate GitHub Copilot aliases
-  if gh extension list | grep -q copilot; then
-    mkdir -p ${DOTFILES_CONFIG}
-    gh copilot alias -- bash >"${DOTFILES_CONFIG}/gh-copilot-bash.sh"
-    gh copilot alias -- zsh >"${DOTFILES_CONFIG}/gh-copilot-zsh.sh"
-    echo "GitHub Copilot aliases generated in ${DOTFILES_CONFIG}"
-  fi
 fi
-
-# vim: set ft=sh ts=2 sw=2 et:

--- a/scripts/gpg-backup.sh
+++ b/scripts/gpg-backup.sh
@@ -5,12 +5,15 @@
 #        Default target directory is current directory
 #        If key_id not provided, will prompt to select from available keys
 
-# Check if running in interactive mode
-if [ -t 0 ] && [ -t 1 ]; then
-  INTERACTIVE=true
-else
-  INTERACTIVE=false
-fi
+# Function to prompt for yes/no confirmation
+prompt() {
+  printf "%s (y/N): " "$1" >&2
+  read choice
+  case "$choice" in
+  [yY] | [yY][eE][sS]) return 0 ;;
+  *) return 1 ;;
+  esac
+}
 
 # Function to discover and select GPG key
 discover_key() {
@@ -57,23 +60,12 @@ discover_key() {
   gpg --list-secret-keys --keyid-format=long "$SELECTED_KEY" >&2
   printf "\n" >&2
 
-  if [ "$INTERACTIVE" = "true" ]; then
-    printf "Use this key for backup? (y/N): " >&2
-    read confirm
-    case "$confirm" in
-    [Yy]*)
-      printf "$SELECTED_KEY"
-      return 0
-      ;;
-    *)
-      printf "Backup cancelled.\n" >&2
-      exit 0
-      ;;
-    esac
-  else
-    printf "Non-interactive mode: using key automatically\n" >&2
+  if prompt "Use this key for backup?"; then
     printf "$SELECTED_KEY"
     return 0
+  else
+    printf "Backup cancelled.\n" >&2
+    exit 0
   fi
 }
 
@@ -123,6 +115,37 @@ if ! gpg --list-secret-keys --keyid-format=long "$KEYID" >/dev/null 2>&1; then
   printf "Available keys:\n"
   gpg --list-secret-keys --keyid-format=long
   exit 1
+fi
+
+# CRITICAL SAFETY CHECK: Ensure we have real private keys, not YubiKey stubs
+printf "Checking key status...\n"
+KEY_LISTING=$(gpg --list-secret-keys --keyid-format=long "$KEYID")
+
+# Check for YubiKey stubs (indicated by '>' symbol)
+if printf "%s" "$KEY_LISTING" | grep -q "ssb>"; then
+  printf "\n❌ ERROR: Cannot backup - subkeys are stored on YubiKey!\n"
+  printf "\nDetected YubiKey stubs (indicated by '>' symbol):\n"
+  printf "%s\n" "$KEY_LISTING" | grep "ssb>" | sed 's/^/  /'
+  printf "\nYubiKey stubs contain no private key material and cannot be backed up.\n"
+  printf "\nValid backup scenarios:\n"
+  printf "  • Before moving keys to YubiKey (initial key generation)\n"
+  printf "  • After restoring from backup (temporary access to private keys)\n"
+  printf "\nIf you need a backup:\n"
+  printf "  1. Use your existing backup (created before YubiKey setup)\n"
+  printf "  2. Or temporarily restore from backup, then create new backup\n"
+  exit 1
+fi
+
+# Warn about backup timing if this appears to be a fresh key
+if ! printf "%s" "$KEY_LISTING" | grep -q "card-no:"; then
+  printf "\n💡 IMPORTANT: This may be your only chance to backup private keys!\n"
+  printf "   Once subkeys are moved to YubiKey, they become stubs and cannot be backed up.\n"
+  printf "   Store this backup securely before proceeding with YubiKey setup.\n"
+
+  if ! prompt "\nContinue with backup?"; then
+    printf "Backup cancelled.\n"
+    exit 0
+  fi
 fi
 
 # Create backup directory name with key ID for uniqueness

--- a/scripts/gpg-backup.sh
+++ b/scripts/gpg-backup.sh
@@ -1,0 +1,232 @@
+#!/bin/sh
+# gpg-backup.sh - Create comprehensive GPG key backup
+#
+# Usage: ./gpg-backup.sh [target_directory] [key_id]
+#        Default target directory is current directory
+#        If key_id not provided, will prompt to select from available keys
+
+# Check if running in interactive mode
+if [ -t 0 ] && [ -t 1 ]; then
+  INTERACTIVE=true
+else
+  INTERACTIVE=false
+fi
+
+# Function to discover and select GPG key
+discover_key() {
+  printf "Scanning for GPG secret keys...\n" >&2
+
+  # Get list of secret keys
+  KEYS=$(gpg --list-secret-keys --keyid-format=long --with-colons | grep "^sec" | cut -d: -f5)
+
+  if [ -z "$KEYS" ]; then
+    printf "Error: No GPG secret keys found!\n"
+    printf "Please create or import a GPG key first.\n"
+    exit 1
+  fi
+
+  # Count keys
+  KEY_COUNT=$(printf "%s\n" "$KEYS" | wc -l | tr -d ' ')
+
+  if [ "$KEY_COUNT" -eq 1 ]; then
+    # Only one key, use it automatically
+    SELECTED_KEY="$KEYS"
+    printf "Found one GPG key: $SELECTED_KEY\n" >&2
+  else
+    # Multiple keys, let user choose
+    printf "\nFound multiple GPG keys:\n" >&2
+    printf "%s\n" "$KEYS" | nl -v0 -s". " >&2
+    printf "\n" >&2
+
+    while true; do
+      printf "Select key number (0-%d): " $((KEY_COUNT - 1)) >&2
+      read selection
+
+      # Validate selection
+      if [ "$selection" -ge 0 ] && [ "$selection" -lt "$KEY_COUNT" ] 2>/dev/null; then
+        SELECTED_KEY=$(printf "%s\n" "$KEYS" | sed -n "$((selection + 1))p")
+        break
+      else
+        printf "Invalid selection. Please enter a number between 0 and %d.\n" $((KEY_COUNT - 1)) >&2
+      fi
+    done
+  fi
+
+  # Show key details
+  printf "\nSelected key details:\n" >&2
+  gpg --list-secret-keys --keyid-format=long "$SELECTED_KEY" >&2
+  printf "\n" >&2
+
+  if [ "$INTERACTIVE" = "true" ]; then
+    printf "Use this key for backup? (y/N): " >&2
+    read confirm
+    case "$confirm" in
+    [Yy]*)
+      printf "$SELECTED_KEY"
+      return 0
+      ;;
+    *)
+      printf "Backup cancelled.\n" >&2
+      exit 0
+      ;;
+    esac
+  else
+    printf "Non-interactive mode: using key automatically\n" >&2
+    printf "$SELECTED_KEY"
+    return 0
+  fi
+}
+
+TIMESTAMP=$(date "+%Y%m%d_%H%M")
+
+# Parse arguments
+TARGET_DIR="."
+KEYID=""
+
+case $# in
+0)
+  # No arguments - use defaults
+  ;;
+1)
+  # One argument - could be target_dir or key_id
+  if gpg --list-secret-keys --keyid-format=long "$1" >/dev/null 2>&1; then
+    # It's a valid key ID
+    KEYID="$1"
+  else
+    # Assume it's a target directory
+    TARGET_DIR="$1"
+  fi
+  ;;
+2)
+  # Two arguments - target_dir and key_id
+  TARGET_DIR="$1"
+  KEYID="$2"
+  ;;
+*)
+  printf "Usage: $0 [target_directory] [key_id]\n"
+  printf "\n"
+  printf "Creates a timestamped GPG backup archive.\n"
+  printf "If key_id not provided, will prompt to select from available keys.\n"
+  printf "Default target directory is current directory.\n"
+  exit 1
+  ;;
+esac
+
+# Discover key if not provided
+if [ -z "$KEYID" ]; then
+  KEYID=$(discover_key)
+fi
+
+# Validate the key exists
+if ! gpg --list-secret-keys --keyid-format=long "$KEYID" >/dev/null 2>&1; then
+  printf "Error: GPG key $KEYID not found!\n"
+  printf "Available keys:\n"
+  gpg --list-secret-keys --keyid-format=long
+  exit 1
+fi
+
+# Create backup directory name with key ID for uniqueness
+SHORT_KEYID=$(printf "%s" "$KEYID" | tail -c 9)
+BACKUP_DIR="gpg-backup-${SHORT_KEYID}-${TIMESTAMP}"
+
+# Create target directory if it doesn't exist
+if [ ! -d "$TARGET_DIR" ]; then
+  printf "Creating target directory: $TARGET_DIR\n"
+  mkdir -p "$TARGET_DIR"
+fi
+
+# Create backup directory path
+BACKUP_PATH="${TARGET_DIR}/${BACKUP_DIR}"
+
+printf "Creating GPG backup for key: ${KEYID}\n"
+printf "Target directory: ${TARGET_DIR}\n"
+printf "Backup directory: ${BACKUP_DIR}\n"
+
+# Create backup directory
+mkdir -p "${BACKUP_PATH}"
+
+printf "Exporting master secret key...\n"
+gpg --armor --export-secret-key ${KEYID} >"${BACKUP_PATH}/${KEYID}-master.asc"
+
+printf "Exporting subkeys...\n"
+gpg --armor --export-secret-subkeys ${KEYID} >"${BACKUP_PATH}/${KEYID}-subkeys.asc"
+
+printf "Exporting public key...\n"
+gpg --armor --export ${KEYID} >"${BACKUP_PATH}/${KEYID}-public.asc"
+
+printf "Exporting SSH public key (from auth subkey)...\n"
+gpg --export-ssh-key ${KEYID}! >"${BACKUP_PATH}/${KEYID}-ssh.pub" 2>/dev/null || printf "Note: No SSH key exported (no auth subkey or not supported)\n"
+
+printf "Exporting trust database...\n"
+gpg --export-ownertrust >"${BACKUP_PATH}/ownertrust.txt"
+
+printf "Copying revocation certificate...\n"
+if [ -f ~/.gnupg/openpgp-revocs.d/${KEYID}.rev ]; then
+  cp ~/.gnupg/openpgp-revocs.d/${KEYID}.rev "${BACKUP_PATH}/"
+else
+  printf "Warning: No revocation certificate found\n"
+fi
+
+# Get key information for README
+KEY_INFO=$(gpg --list-secret-keys --keyid-format=long "$KEYID")
+CREATION_DATE=$(printf "%s" "$KEY_INFO" | grep "created:" | head -1 | sed 's/.*created: \([0-9-]*\).*/\1/' || date +%Y-%m-%d)
+
+# Extract User IDs
+USER_IDS=$(gpg --list-keys --with-colons "$KEYID" | grep "^uid" | cut -d: -f10 | sed 's/.*<\(.*\)>.*/\1/' | head -5)
+
+# Get subkey information
+SUBKEY_INFO=$(gpg --list-secret-keys --keyid-format=long "$KEYID" | grep "^ssb" | head -5)
+
+# Create README with key information
+cat >"${BACKUP_PATH}/README.txt" <<EOF
+GPG Key Backup - ${TIMESTAMP}
+=============================
+
+Master Key ID: ${KEYID}
+Creation Date: ${CREATION_DATE}
+Backup Created: $(date)
+
+User IDs:
+$(printf "%s\n" "$USER_IDS" | sed 's/^/- /')
+
+Key Structure:
+$(printf "%s\n" "$SUBKEY_INFO" | sed 's/^/- /')
+
+Files in this backup:
+- ${KEYID}-master.asc: Master secret key
+- ${KEYID}-subkeys.asc: All subkeys
+- ${KEYID}-public.asc: Public key for sharing
+- ${KEYID}-ssh.pub: SSH public key (if available)
+- ownertrust.txt: Trust database
+- ${KEYID}.rev: Revocation certificate (if exists)
+
+Restore commands:
+==============
+Use gpg-restore.sh script with this backup file.
+
+Or manually:
+gpg --import ${KEYID}-master.asc
+gpg --import ${KEYID}-subkeys.asc
+gpg --import-ownertrust ownertrust.txt
+
+To move subkeys to YubiKey after restore:
+gpg --expert --edit-key ${KEYID}
+(Select each subkey and use 'keytocard' command)
+
+Store this backup securely offline!
+EOF
+
+# Create tarball in target directory
+BACKUP_FILE="${TARGET_DIR}/${BACKUP_DIR}.tar.gz"
+tar -czf "${BACKUP_FILE}" -C "${TARGET_DIR}" "${BACKUP_DIR}"
+rm -rf "${BACKUP_PATH}"
+
+printf "\n"
+printf "✅ Backup created: ${BACKUP_FILE}\n"
+printf "📁 Size: %s\n" "$(du -h "${BACKUP_FILE}" | cut -f1)"
+printf "\n"
+printf "🔐 IMPORTANT: Store this backup securely!\n"
+printf "📝 Use gpg-restore.sh to restore to a YubiKey\n"
+printf "\n"
+printf "Example restore usage:\n"
+printf "  ./gpg-restore.sh \"${BACKUP_FILE}\"\n"

--- a/scripts/gpg-restore.sh
+++ b/scripts/gpg-restore.sh
@@ -1,0 +1,193 @@
+#!/bin/sh
+# Restore GPG key from backup to YubiKey
+#
+# Usage: ./gpg-restore.sh backup.tar.gz
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+BACKUP_FILE="$1"
+
+# Check if backup file is provided
+if [ -z "$BACKUP_FILE" ]; then
+  printf "${RED}Usage: $0 backup.tar.gz${NC}\n"
+  printf "\n"
+  printf "Restores GPG key from backup to YubiKey.\n"
+  exit 1
+fi
+
+printf "${BLUE}🔑 GPG YubiKey Restore Script${NC}\n"
+printf "===============================\n"
+printf "\n"
+
+# Check if backup file exists
+if [ ! -f "$BACKUP_FILE" ]; then
+  printf "${RED}❌ Error: Backup file not found: $BACKUP_FILE${NC}\n"
+  exit 1
+fi
+
+# Check if it's a .tar.gz file
+case "$BACKUP_FILE" in
+*.tar.gz) ;;
+*)
+  printf "${RED}❌ Error: File must be a .tar.gz archive${NC}\n"
+  exit 1
+  ;;
+esac
+
+printf "${GREEN}✅ Found backup file: $BACKUP_FILE${NC}\n"
+
+# Check if YubiKey is detected
+if ! command -v ykman >/dev/null 2>&1; then
+  printf "${RED}❌ Error: ykman not found! Please install YubiKey Manager.${NC}\n"
+  exit 1
+fi
+
+if ! ykman list | grep -q "YubiKey"; then
+  printf "${RED}❌ Error: No YubiKey detected!${NC}\n"
+  printf "Please insert your YubiKey and try again.\n"
+  exit 1
+fi
+
+printf "${GREEN}✅ YubiKey detected${NC}\n"
+
+# Show YubiKey info
+printf "\n${BLUE}YubiKey Information:${NC}\n"
+ykman info
+printf "\n"
+
+# Warning about reset
+printf "${YELLOW}⚠️  WARNING: This will reset the YubiKey's OpenPGP applet!${NC}\n"
+printf "   All existing OpenPGP keys on the YubiKey will be erased.\n"
+printf "\n"
+printf "Continue with YubiKey reset and restore? (type 'yes' to continue): "
+read confirm
+if [ "$confirm" != "yes" ]; then
+  printf "Operation cancelled.\n"
+  exit 0
+fi
+
+# Create temporary directory for extraction
+TEMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'gpg-restore')
+
+printf "\n${BLUE}Step 1: Extracting backup...${NC}\n"
+tar -xzf "$BACKUP_FILE" -C "$TEMP_DIR"
+
+# Find the extracted directory
+EXTRACT_DIR=""
+for dir in "$TEMP_DIR"/*/; do
+  if [ -d "$dir" ]; then
+    EXTRACT_DIR="${dir%/}"
+    break
+  fi
+done
+
+if [ -z "$EXTRACT_DIR" ]; then
+  printf "${RED}❌ Error: Could not find extracted directory${NC}\n"
+  exit 1
+fi
+
+# Auto-detect the KEYID from the filenames
+KEYID=""
+for file in "$EXTRACT_DIR"/*-master.asc; do
+  if [ -f "$file" ]; then
+    KEYID=$(basename "$file" | sed 's/-master\.asc$//')
+    break
+  fi
+done
+
+if [ -z "$KEYID" ]; then
+  printf "${RED}❌ Error: Could not detect GPG key ID from backup files${NC}\n"
+  exit 1
+fi
+
+printf "${BLUE}Detected Key ID: $KEYID${NC}\n"
+
+# Verify required files exist
+printf "\n${BLUE}Verifying backup contents:${NC}\n"
+for file in "${KEYID}-master.asc" "${KEYID}-subkeys.asc" "ownertrust.txt"; do
+  if [ -f "$EXTRACT_DIR/$file" ]; then
+    printf "  ${GREEN}✅ $file${NC}\n"
+  else
+    printf "  ${RED}❌ $file (missing)${NC}\n"
+    printf "${RED}❌ Error: Required backup files are missing!${NC}\n"
+    exit 1
+  fi
+done
+
+printf "\n${BLUE}Step 2: Resetting YubiKey OpenPGP applet...${NC}\n"
+ykman openpgp reset
+
+printf "\n${BLUE}Step 3: Importing GPG keys...${NC}\n"
+
+# Import master key
+printf "Importing master key...\n"
+gpg --import "$EXTRACT_DIR/${KEYID}-master.asc"
+
+# Import subkeys
+printf "Importing subkeys...\n"
+gpg --import "$EXTRACT_DIR/${KEYID}-subkeys.asc"
+
+# Import trust settings
+printf "Importing trust settings...\n"
+gpg --import-ownertrust "$EXTRACT_DIR/ownertrust.txt"
+
+printf "\n${BLUE}Step 4: Cleaning up old YubiKey stubs...${NC}\n"
+# Remove any existing YubiKey key stubs that might conflict
+find ~/.gnupg/private-keys-v1.d/ -name "*.key" -delete 2>/dev/null || true
+
+full_name=$(id -F 2>/dev/null || id -un)
+login_user=$(gh api user --jq '.login' 2>/dev/null || whoami)
+
+printf "\n${BLUE}Step 5: Instructions for YubiKey Configuration${NC}\n"
+printf "You'll be prompted to configure your YubiKey with these recommended settings:\n"
+printf "  - Admin PIN: 8+ digits (default: 12345678)\n"
+printf "  - User PIN: 6+ digits (default: 123456)\n"
+printf "  - Name: ${full_name}\n"
+printf "  - Login: ${login_user}\n"
+printf "  - URL: https://github.com/${login_user}.gpg\n"
+printf "\n"
+read dummy
+
+# Configure YubiKey - user must do this interactively
+printf "\n${BLUE}Starting YubiKey configuration...${NC}\n"
+gpg --card-edit
+
+printf "${BLUE}Step 6: Instructions for Moving Subkeys to YubiKey${NC}\n"
+printf "\n${YELLOW}⚠️  IMPORTANT: This will move your private subkeys to the YubiKey.${NC}\n"
+printf "   After this, the keys will only exist on the YubiKey hardware!\n"
+printf "\n"
+printf "In the GPG key editing prompt, run these commands:\n"
+printf "  ${GREEN}key 2${NC} (select signing subkey)\n"
+printf "  ${GREEN}keytocard${NC} -> select ${GREEN}1${NC} (Signature key)\n"
+printf "  ${GREEN}key 2${NC} (deselect)\n"
+printf "  ${GREEN}key 3${NC} (select encryption subkey)\n"
+printf "  ${GREEN}keytocard${NC} -> select ${GREEN}2${NC} (Encryption key)\n"
+printf "  ${GREEN}key 3${NC} (deselect)\n"
+printf "  ${GREEN}key 4${NC} (select authentication subkey)\n"
+printf "  ${GREEN}keytocard${NC} -> select ${GREEN}3${NC} (Authentication key)\n"
+printf "  ${GREEN}save${NC}\n"
+printf "\n"
+printf "Press Enter to start YubiKey configuration..."
+printf "\n${BLUE}Starting key transfer to YubiKey...${NC}\n"
+read dummy
+
+# Start GPG edit session for moving keys to card
+gpg --expert --edit-key "$KEYID"
+
+printf "\n${BLUE}Step 7: Verifying YubiKey setup...${NC}\n"
+gpg --card-status
+
+printf "\n${GREEN}✅ YubiKey restore process complete!${NC}\n"
+
+# Cleanup
+rm -rf "$TEMP_DIR"
+
+printf "\n${BLUE}Next steps:${NC}\n"
+printf "1. Test GPG signing: echo 'test' | gpg --clearsign\n"
+printf "2. Test Git signing: git commit --allow-empty -m 'Test GPG signing'\n"
+printf "\n${YELLOW}💡 Your YubiKey is now ready to use!${NC}\n"

--- a/scripts/gpg-restore.sh
+++ b/scripts/gpg-restore.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Restore GPG key from backup to YubiKey
+# gpg-restore.sh - Restore GPG key from backup to YubiKey
 #
 # Usage: ./gpg-restore.sh backup.tar.gz
 
@@ -10,15 +10,53 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
-BACKUP_FILE="$1"
+# Function to prompt for yes/no confirmation
+prompt() {
+  printf "%s (y/N): " "$1" >&2
+  read choice
+  case "$choice" in
+  [yY] | [yY][eE][sS]) return 0 ;;
+  *) return 1 ;;
+  esac
+}
 
-# Check if backup file is provided
-if [ -z "$BACKUP_FILE" ]; then
-  printf "${RED}Usage: $0 backup.tar.gz${NC}\n"
+# Show usage
+show_usage() {
+  printf "Usage: $0 backup.tar.gz\n"
   printf "\n"
   printf "Restores GPG key from backup to YubiKey.\n"
+  printf "\n"
+  printf "Options:\n"
+  printf "  -h    Show this help message\n"
+}
+
+# Parse options with getopts
+while getopts "h" opt; do
+  case $opt in
+  h)
+    show_usage
+    exit 0
+    ;;
+  \?)
+    printf "${RED}Invalid option: -$OPTARG${NC}\n" >&2
+    show_usage
+    exit 1
+    ;;
+  esac
+done
+
+# Shift past the options
+shift $((OPTIND - 1))
+
+# Check if backup file is provided
+if [ $# -ne 1 ]; then
+  printf "${RED}Error: backup.tar.gz file is required${NC}\n"
+  printf "\n"
+  show_usage
   exit 1
 fi
+
+BACKUP_FILE="$1"
 
 printf "${BLUE}🔑 GPG YubiKey Restore Script${NC}\n"
 printf "===============================\n"
@@ -60,21 +98,10 @@ printf "\n${BLUE}YubiKey Information:${NC}\n"
 ykman info
 printf "\n"
 
-# Warning about reset
-printf "${YELLOW}⚠️  WARNING: This will reset the YubiKey's OpenPGP applet!${NC}\n"
-printf "   All existing OpenPGP keys on the YubiKey will be erased.\n"
-printf "\n"
-printf "Continue with YubiKey reset and restore? (type 'yes' to continue): "
-read confirm
-if [ "$confirm" != "yes" ]; then
-  printf "Operation cancelled.\n"
-  exit 0
-fi
-
 # Create temporary directory for extraction
 TEMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'gpg-restore')
 
-printf "\n${BLUE}Step 1: Extracting backup...${NC}\n"
+printf "${BLUE}Step 1: Extracting backup...${NC}\n"
 tar -xzf "$BACKUP_FILE" -C "$TEMP_DIR"
 
 # Find the extracted directory
@@ -88,6 +115,7 @@ done
 
 if [ -z "$EXTRACT_DIR" ]; then
   printf "${RED}❌ Error: Could not find extracted directory${NC}\n"
+  rm -rf "$TEMP_DIR"
   exit 1
 fi
 
@@ -102,6 +130,7 @@ done
 
 if [ -z "$KEYID" ]; then
   printf "${RED}❌ Error: Could not detect GPG key ID from backup files${NC}\n"
+  rm -rf "$TEMP_DIR"
   exit 1
 fi
 
@@ -115,14 +144,65 @@ for file in "${KEYID}-master.asc" "${KEYID}-subkeys.asc" "ownertrust.txt"; do
   else
     printf "  ${RED}❌ $file (missing)${NC}\n"
     printf "${RED}❌ Error: Required backup files are missing!${NC}\n"
+    rm -rf "$TEMP_DIR"
     exit 1
   fi
 done
 
+# Check if key already exists locally
+KEY_EXISTS=false
+if gpg --list-secret-keys "$KEYID" >/dev/null 2>&1; then
+  KEY_EXISTS=true
+fi
+
+# Check current YubiKey status
+YUBIKEY_HAS_KEYS=false
+if gpg --card-status 2>/dev/null | grep -q "Signature key"; then
+  YUBIKEY_HAS_KEYS=true
+fi
+
+# Display current state and options
+printf "\n${BLUE}Current State Analysis:${NC}\n"
+if [ "$KEY_EXISTS" = "true" ]; then
+  printf "  ${GREEN}✅ GPG key $KEYID already exists locally${NC}\n"
+else
+  printf "  ${YELLOW}ℹ️  GPG key $KEYID not found locally${NC}\n"
+fi
+
+if [ "$YUBIKEY_HAS_KEYS" = "true" ]; then
+  printf "  ${YELLOW}⚠️  YubiKey already contains OpenPGP keys${NC}\n"
+  gpg --card-status | grep -E "(Signature key|Encryption key|Authentication key)" | sed 's/^/    /'
+else
+  printf "  ${GREEN}ℹ️  YubiKey OpenPGP applet is empty${NC}\n"
+fi
+
+# Determine operation mode
+printf "\n${BLUE}Operation: Restore GPG key to YubiKey${NC}\n"
+printf "This will import keys from backup and move subkeys to YubiKey.\n"
+
+# Warning and confirmation
+printf "\n"
+printf "${YELLOW}⚠️  WARNING: This will reset the YubiKey's OpenPGP applet!${NC}\n"
+if [ "$YUBIKEY_HAS_KEYS" = "true" ]; then
+  printf "   Existing YubiKey keys will be erased.\n"
+fi
+if [ "$KEY_EXISTS" = "true" ]; then
+  printf "   Local keys will be reimported from backup.\n"
+fi
+
+printf "\n"
+if ! prompt "Continue with this operation?"; then
+  printf "Operation cancelled.\n"
+  rm -rf "$TEMP_DIR"
+  exit 0
+fi
+
+# Reset YubiKey OpenPGP applet
 printf "\n${BLUE}Step 2: Resetting YubiKey OpenPGP applet...${NC}\n"
 ykman openpgp reset
 
-printf "\n${BLUE}Step 3: Importing GPG keys...${NC}\n"
+# Import keys - always import from backup to ensure we have the private key material
+printf "\n${BLUE}Step 3: Importing GPG keys from backup...${NC}\n"
 
 # Import master key
 printf "Importing master key...\n"
@@ -140,26 +220,36 @@ printf "\n${BLUE}Step 4: Cleaning up old YubiKey stubs...${NC}\n"
 # Remove any existing YubiKey key stubs that might conflict
 find ~/.gnupg/private-keys-v1.d/ -name "*.key" -delete 2>/dev/null || true
 
-full_name=$(id -F 2>/dev/null || id -un)
+# Re-import subkeys to ensure we have local copies for moving to card
+printf "Ensuring local subkey copies are available for transfer...\n"
+gpg --import "$EXTRACT_DIR/${KEYID}-subkeys.asc"
+
+# Get user info for YubiKey configuration
+full_name=$(gpg --list-keys --with-colons "$KEYID" | grep "^uid" | head -1 | cut -d: -f10 | sed 's/ <.*//' | sed 's/.*(//' | sed 's/).*//')
+if [ -z "$full_name" ]; then
+  full_name=$(id -F 2>/dev/null || id -un)
+fi
+
 login_user=$(gh api user --jq '.login' 2>/dev/null || whoami)
 
-printf "\n${BLUE}Step 5: Instructions for YubiKey Configuration${NC}\n"
-printf "You'll be prompted to configure your YubiKey with these recommended settings:\n"
+printf "\n${BLUE}Step 5: YubiKey Configuration${NC}\n"
+printf "Configure your YubiKey with these recommended settings:\n"
 printf "  - Admin PIN: 8+ digits (default: 12345678)\n"
 printf "  - User PIN: 6+ digits (default: 123456)\n"
 printf "  - Name: ${full_name}\n"
 printf "  - Login: ${login_user}\n"
 printf "  - URL: https://github.com/${login_user}.gpg\n"
 printf "\n"
+printf "Press Enter to start YubiKey configuration..."
 read dummy
 
 # Configure YubiKey - user must do this interactively
 printf "\n${BLUE}Starting YubiKey configuration...${NC}\n"
 gpg --card-edit
 
-printf "${BLUE}Step 6: Instructions for Moving Subkeys to YubiKey${NC}\n"
+printf "\n${BLUE}Step 6: Moving Subkeys to YubiKey${NC}\n"
 printf "\n${YELLOW}⚠️  IMPORTANT: This will move your private subkeys to the YubiKey.${NC}\n"
-printf "   After this, the keys will only exist on the YubiKey hardware!\n"
+printf "   After this, the subkeys will only exist on the YubiKey hardware!\n"
 printf "\n"
 printf "In the GPG key editing prompt, run these commands:\n"
 printf "  ${GREEN}key 2${NC} (select signing subkey)\n"
@@ -172,15 +262,19 @@ printf "  ${GREEN}key 4${NC} (select authentication subkey)\n"
 printf "  ${GREEN}keytocard${NC} -> select ${GREEN}3${NC} (Authentication key)\n"
 printf "  ${GREEN}save${NC}\n"
 printf "\n"
-printf "Press Enter to start YubiKey configuration..."
-printf "\n${BLUE}Starting key transfer to YubiKey...${NC}\n"
+printf "Press Enter to start the key transfer process..."
 read dummy
 
 # Start GPG edit session for moving keys to card
+printf "\n${BLUE}Starting key transfer to YubiKey...${NC}\n"
 gpg --expert --edit-key "$KEYID"
 
 printf "\n${BLUE}Step 7: Verifying YubiKey setup...${NC}\n"
+printf "YubiKey card status:\n"
 gpg --card-status
+
+printf "\nSecret keys status:\n"
+gpg --list-secret-keys --keyid-format=long "$KEYID"
 
 printf "\n${GREEN}✅ YubiKey restore process complete!${NC}\n"
 
@@ -191,3 +285,7 @@ printf "\n${BLUE}Next steps:${NC}\n"
 printf "1. Test GPG signing: echo 'test' | gpg --clearsign\n"
 printf "2. Test Git signing: git commit --allow-empty -m 'Test GPG signing'\n"
 printf "\n${YELLOW}💡 Your YubiKey is now ready to use!${NC}\n"
+printf "\n${BLUE}Multi-YubiKey Usage:${NC}\n"
+printf "• Run this script again with other YubiKeys to set them up identically\n"
+printf "• All YubiKeys with the same subkeys work interchangeably\n"
+printf "• GPG will work with whichever YubiKey is currently inserted\n"

--- a/scripts/gpg.sh
+++ b/scripts/gpg.sh
@@ -30,3 +30,10 @@ Darwin)
   fi
   ;;
 esac
+
+# Import GitHub published GPG keys
+ghuser=""
+if command -v gh >/dev/null 2>&1; then
+  ghuser=$(gh api user --jq '.login')
+  curl -fsSL https://github.com/$ghuser.gpg | gpg --import
+fi

--- a/scripts/gpg.sh
+++ b/scripts/gpg.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# gpg configuration script
+
+set -eu
+
+# Set default values for environment variables if not already set
+: "${XDG_CONFIG_HOME:=${HOME}/.config}"
+: "${DOTFILES:=${XDG_DATA_HOME:-${HOME}/.local/share}/dotfiles}"
+
+case $(uname -s) in
+Darwin)
+  if command -v pinentry-mac >/dev/null 2>&1; then
+    # Configure pinentry-mac to use the macOS keychain
+    defaults write org.gpgtools.pinentry-mac UseKeychain -bool YES
+    defaults write org.gpgtools.pinentry-mac DisableKeychain -bool NO
+
+    # Set pinentry-mac as the default pinentry program in ~/.gnupg/gpg-agent.conf
+    gpg_agent_conf="$HOME/.gnupg/gpg-agent.conf"
+    pinentry_path=$(which pinentry-mac)
+
+    # Create .gnupg directory if it doesn't exist with correct permissions
+    mkdir -p "$HOME/.gnupg"
+    chmod 700 "$HOME/.gnupg"
+
+    # Check if pinentry-program is already set
+    if [ ! -f "$gpg_agent_conf" ] || ! grep -q "^pinentry-program" "$gpg_agent_conf"; then
+      echo "pinentry-program $pinentry_path" >>"$gpg_agent_conf"
+    fi
+  fi
+  ;;
+esac

--- a/scripts/ssh.sh
+++ b/scripts/ssh.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+
+# SSH configuration script
+
+set -eu
+
+# Set default values for environment variables if not already set
+: "${XDG_CONFIG_HOME:=${HOME}/.config}"
+: "${DOTFILES:=${XDG_DATA_HOME:-${HOME}/.local/share}/dotfiles}"
+
+SSH_CONFIG="${HOME}/.ssh/config"
+SSH_DIR="${HOME}/.ssh"
+DOTFILES_SSH_CONFIG="${XDG_CONFIG_HOME}/ssh/config"
+
+# Check if a line exists in SSH config
+ssh_config_has_line() {
+  local config_file="$1"
+  local pattern="$2"
+  [ -f "$config_file" ] && grep -q "$pattern" "$config_file"
+}
+
+# Add a line to config if it doesn't exist
+add_to_ssh_config() {
+  local config_file="$1"
+  local line="$2"
+  local pattern="$3"
+
+  if ! ssh_config_has_line "$config_file" "$pattern"; then
+    echo "Added: $line"
+    printf "%s\n" "$line" >>"$config_file"
+  fi
+}
+
+# Install security key helper
+case $(uname -s) in
+Darwin)
+  if command -v brew >/dev/null 2>&1 && [ -n "$HOMEBREW_PREFIX" ]; then
+    brew install --formula "${DOTFILES}/formula/sk-libfido2.rb"
+  else
+    echo "Homebrew is not installed. Please install Homebrew first."
+    exit 1
+  fi
+  ;;
+esac
+
+# Create SSH config if it doesn't exist
+if [ ! -f "${SSH_CONFIG}" ]; then
+  mkdir -p "${SSH_DIR}"
+  touch "${SSH_CONFIG}"
+fi
+
+# Add Include directive for dotfiles SSH config
+if [ -f "$DOTFILES_SSH_CONFIG" ]; then
+  INCLUDE_LINE="Include ${DOTFILES_SSH_CONFIG}"
+
+  # Check if Include is already at the top of the file
+  if ! head -n 5 "$SSH_CONFIG" | grep -q "Include.*${DOTFILES_SSH_CONFIG}"; then
+    # Create a temporary file with the Include at the top
+    TEMP_CONFIG=$(mktemp)
+    echo "$INCLUDE_LINE" >"$TEMP_CONFIG"
+    echo "" >>"$TEMP_CONFIG"
+    cat "$SSH_CONFIG" >>"$TEMP_CONFIG"
+    mv "$TEMP_CONFIG" "$SSH_CONFIG"
+    echo "Added: Include dotfiles ssh config"
+  fi
+else
+  echo "Warning: Dotfiles SSH config not found at $DOTFILES_SSH_CONFIG"
+fi
+
+# Add security key provider
+case $(uname -s) in
+Darwin)
+  if [ -f "${HOMEBREW_PREFIX}/lib/sk-libfido2.dylib" ]; then
+    SECURITY_KEY_LINE="SecurityKeyProvider ${HOMEBREW_PREFIX}/lib/sk-libfido2.dylib"
+    add_to_ssh_config "$SSH_CONFIG" "$SECURITY_KEY_LINE" "SecurityKeyProvider.*sk-libfido2"
+  fi
+  ;;
+Linux)
+  # Check for libfido2 library in common locations
+  for lib_path in "/usr/lib/x86_64-linux-gnu/sk-libfido2.so" "/usr/lib/sk-libfido2.so" "/usr/local/lib/sk-libfido2.so"; do
+    if [ -f "$lib_path" ]; then
+      SECURITY_KEY_LINE="SecurityKeyProvider $lib_path"
+      add_to_ssh_config "$SSH_CONFIG" "$SECURITY_KEY_LINE" "SecurityKeyProvider.*sk-libfido2"
+      break
+    fi
+  done
+  ;;
+esac
+
+# Set permissions on SSH config
+chmod 700 "${SSH_DIR}"
+chmod 600 "${SSH_CONFIG}"
+
+echo "SSH configuration complete!"
+echo ""
+echo "SSH config location: $SSH_CONFIG"
+echo "dotfiles SSH config: $DOTFILES_SSH_CONFIG"
+
+# Display helpful information
+case $(uname -s) in
+Darwin)
+  if [ -n "$HOMEBREW_PREFIX" ] && [ -f "${HOMEBREW_PREFIX}/lib/sk-libfido2.dylib" ]; then
+    echo ""
+    echo "Security key support is now configured!"
+    echo "To generate a resident key:"
+    echo "  ssh-keygen -t ed25519-sk -O resident -O verify-required -f ~/.ssh/id_ed25519_sk"
+    echo "To load resident keys from your security key:"
+    echo "  ssh-add -K"
+  fi
+  ;;
+esac

--- a/scripts/ssh.sh
+++ b/scripts/ssh.sh
@@ -27,7 +27,7 @@ add_to_ssh_config() {
 
   if ! ssh_config_has_line "$config_file" "$pattern"; then
     echo "Added: $line"
-    printf "%s\n" "$line" >>"$config_file"
+    printf "\n%s\n\n" "$line" >>"$config_file"
   fi
 }
 
@@ -38,9 +38,6 @@ Darwin)
     brew install --formula "${DOTFILES}/formula/sk-libfido2.rb"
     echo "Install security key provider"
     sudo cp ${HOMEBREW_PREFIX}/lib/sk-libfido2.dylib /usr/local/lib/sk-libfido2.dylib
-  else
-    echo "Homebrew is not installed. Please install Homebrew first."
-    exit 1
   fi
   ;;
 esac
@@ -69,26 +66,55 @@ else
   echo "Warning: Dotfiles SSH config not found at $DOTFILES_SSH_CONFIG"
 fi
 
-# Add security key provider
+# Add security key providers
 SECURITY_KEY_LINE=""
+PKCS11_PROVIDER_LINE=""
 case $(uname -s) in
 Darwin)
-  if [ -f /usr/local/lib/sk-libfido2.dylib ]; then
-    SECURITY_KEY_LINE="SecurityKeyProvider /usr/local/lib/sk-libfido2.dylib"
-  fi
+  fido2_libs="/usr/local/lib/sk-libfido2.dylib"
+  for lib_path in $fido2_libs; do
+    if [ -f "$lib_path" ]; then
+      echo "Setting SecurityKeyProvider $lib_path"
+      SECURITY_KEY_LINE="SecurityKeyProvider $lib_path"
+      launchctl setenv SSH_SK_PROVIDER "$lib_path"
+      break
+    fi
+  done
+
+  # Configure SSH_ASKPASS helper
+  echo "Setting SSH_ASKPASS launchctl environment variable..."
+  launchctl setenv SSH_ASKPASS "${DOTFILES}/bin/ssh-askpass"
+  launchctl setenv SSH_ASKPASS_REQUIRE force
+
+  pkcs11_libs="${HOMEBREW_PREFIX}/lib/libykcs11.dylib ${HOMEBREW_PREFIX}/lib/opensc-pkcs11.dylib /usr/lib/ssh-keychain.dylib"
+  echo $pkcs11_libs
+  for lib_path in $pkcs11_libs; do
+    echo "Checking $lib_path..."
+    if [ -f "$lib_path" ]; then
+      echo "Setting PKCS11Provider $lib_path"
+      PKCS11_PROVIDER_LINE="PKCS11Provider $lib_path"
+      break
+    fi
+  done
   ;;
 Linux)
   # Check for libfido2 library in common locations
-  for lib_path in "/usr/lib/x86_64-linux-gnu/sk-libfido2.so" "/usr/lib/sk-libfido2.so" "/usr/local/lib/sk-libfido2.so"; do
+  fido2_libs="/usr/lib/x86_64-linux-gnu/sk-libfido2.so /usr/lib/sk-libfido2.so /usr/local/lib/sk-libfido2.so"
+  for lib_path in $fido2_libs; do
     if [ -f "$lib_path" ]; then
+      echo "Setting SecurityKeyProvider $lib_path"
       SECURITY_KEY_LINE="SecurityKeyProvider $lib_path"
       break
     fi
   done
   ;;
 esac
+
 if [ -n "$SECURITY_KEY_LINE" ]; then
-  add_to_ssh_config "$SSH_CONFIG" "$SECURITY_KEY_LINE" "SecurityKeyProvider.*sk-libfido2"
+  add_to_ssh_config "$SSH_CONFIG" "$SECURITY_KEY_LINE" "SecurityKeyProvider.*"
+fi
+if [ -n "$PKCS11_PROVIDER_LINE" ]; then
+  add_to_ssh_config "$SSH_CONFIG" "$PKCS11_PROVIDER_LINE" "PKCS11Provider.*"
 fi
 
 # Set permissions on SSH config

--- a/scripts/ssh.sh
+++ b/scripts/ssh.sh
@@ -36,6 +36,8 @@ case $(uname -s) in
 Darwin)
   if command -v brew >/dev/null 2>&1 && [ -n "$HOMEBREW_PREFIX" ]; then
     brew install --formula "${DOTFILES}/formula/sk-libfido2.rb"
+    echo "Install security key provider"
+    sudo cp ${HOMEBREW_PREFIX}/lib/sk-libfido2.dylib /usr/local/lib/sk-libfido2.dylib
   else
     echo "Homebrew is not installed. Please install Homebrew first."
     exit 1
@@ -68,11 +70,11 @@ else
 fi
 
 # Add security key provider
+SECURITY_KEY_LINE=""
 case $(uname -s) in
 Darwin)
-  if [ -f "${HOMEBREW_PREFIX}/lib/sk-libfido2.dylib" ]; then
-    SECURITY_KEY_LINE="SecurityKeyProvider ${HOMEBREW_PREFIX}/lib/sk-libfido2.dylib"
-    add_to_ssh_config "$SSH_CONFIG" "$SECURITY_KEY_LINE" "SecurityKeyProvider.*sk-libfido2"
+  if [ -f /usr/local/lib/sk-libfido2.dylib ]; then
+    SECURITY_KEY_LINE="SecurityKeyProvider /usr/local/lib/sk-libfido2.dylib"
   fi
   ;;
 Linux)
@@ -80,12 +82,14 @@ Linux)
   for lib_path in "/usr/lib/x86_64-linux-gnu/sk-libfido2.so" "/usr/lib/sk-libfido2.so" "/usr/local/lib/sk-libfido2.so"; do
     if [ -f "$lib_path" ]; then
       SECURITY_KEY_LINE="SecurityKeyProvider $lib_path"
-      add_to_ssh_config "$SSH_CONFIG" "$SECURITY_KEY_LINE" "SecurityKeyProvider.*sk-libfido2"
       break
     fi
   done
   ;;
 esac
+if [ -n "$SECURITY_KEY_LINE" ]; then
+  add_to_ssh_config "$SSH_CONFIG" "$SECURITY_KEY_LINE" "SecurityKeyProvider.*sk-libfido2"
+fi
 
 # Set permissions on SSH config
 chmod 700 "${SSH_DIR}"

--- a/src/.config/git/config
+++ b/src/.config/git/config
@@ -44,12 +44,6 @@
 [instaweb]
 	httpd = webrick
 
-[filter "lfs"]
-	clean = git-lfs clean -- %f
-	smudge = git-lfs smudge -- %f
-	process = git-lfs filter-process
-	required = true
-
 [diff]
 	gui = auto
 

--- a/src/.config/homebrew/Brewfile
+++ b/src/.config/homebrew/Brewfile
@@ -28,6 +28,11 @@ brew "ruby-build"
 brew "rustup"
 
 if OS.mac?
+  brew "gnupg"
+  brew "pinentry"
+  brew "pinentry-mac"
+  brew "yubico-piv-tool"
+
   cask_args adopt: true
   cask "bbedit"
   cask "chatgpt"
@@ -43,7 +48,7 @@ if OS.mac?
   cask "xquartz"
   cask "xscope"
   cask "yubico-authenticator"
-  cask "zed@preview"
+
   # 3rd party utilities
   tap "teamookla/speedtest"
   brew "teamookla/speedtest/speedtest"

--- a/src/.config/ssh/config
+++ b/src/.config/ssh/config
@@ -1,3 +1,7 @@
+Host *
+	IdentityAgent none
+	IdentitiesOnly yes
+
 Host github.com
 	User git
 	IdentitiesOnly yes

--- a/src/.config/ssh/config
+++ b/src/.config/ssh/config
@@ -1,6 +1,3 @@
-Host *
-	AddKeysToAgent yes
-
 Host github.com
 	User git
 	IdentitiesOnly yes

--- a/src/.config/ssh/config
+++ b/src/.config/ssh/config
@@ -1,2 +1,6 @@
-Match host * exec "test -z $SSH_TTY && test -S ~/.1password/agent.sock"
-    IdentityAgent "~/.1password/agent.sock"
+Host *
+	AddKeysToAgent yes
+
+Host github.com
+	User git
+	IdentitiesOnly yes

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -6,7 +6,6 @@ set -eu
 
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 XDG_DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
-LOCAL_BIN_HOME=${LOCAL_BIN_HOME:-$HOME/.local/bin}
 DOTFILES=${DOTFILES:-${XDG_DATA_HOME}/dotfiles}
 DOTFILES_CONFIG=${DOTFILES_CONFIG:-${XDG_CONFIG_HOME}/dotfiles}
 TARGET=${TARGET:-$HOME}
@@ -55,15 +54,6 @@ remove_path() {
 
 # Remove dotfiles configuration
 ${DOTFILES}/bin/dotfiles ${FLAGS} -d ${DOTFILES} -t ${TARGET} unlink
-
-# Remove symlinks
-for dfbin in ${DOTFILES}/bin/*; do
-  bin="$LOCAL_BIN_HOME/${dfbin##*/}"
-  if [ -L $bin ]; then
-    echo "Remove $bin"
-    rm $bin
-  fi
-done
 
 remove_path "${DOTFILES_CONFIG}"
 remove_path "${DOTFILES}"


### PR DESCRIPTION
This PR introduces FIDO2/YubiKey support and related developer experience improvements across the dotfiles repo.

Highlights
- Replace 1Password SSH agent with native FIDO2/YubiKey support
- Enable commit signing with GPG backed by YubiKey (switch from SSH signing)
- Add GPG backup and restore scripts for YubiKey smartcard keys
- Configure macOS pinentry and gpg-agent for GUI prompts
- Enhance SSH configuration for security key providers on macOS
- Add YubiKey and GPG tooling to Homebrew provisioning
- Improve dotfiles script handling and environment setup

Commit summary
- be1e191 Remove 1Password SSH agent and add FIDO2/YubiKey support
- bf33ccc Update FIDO2 provider path and SSH config handling
- 7963910 Enable commit signing by default in gc_commitsigning
- c2d5d8e Add ssh-askpass script and update bin path handling
- e35fead Set Homebrew download concurrency and SSH_ASKPASS env vars
- 4f1a0b2 Improve SSH config setup for security key providers on macOS
- 263667e Add YubiKey SSH key management to gitconfig
- 4653765 Add gpg configuration script for macOS pinentry setup
- 4a7586b Switch commit signing from SSH to GPG with YubiKey
- ac11487 Add GPG backup and restore scripts for YubiKey
- 9ad5845 Improve dotfiles script handling and enhance GPG backup/restore
- a851b08 Set GPG environment for SSH sessions; remove bin symlink setup
- c5efb45 Add GPG and Yubico tools to macOS Brewfile

Notes
- Local uncommitted changes are present but not included in this PR (see git status).